### PR TITLE
fix setting size to 0px

### DIFF
--- a/src/collective/flowplayer/browser/js/init.js
+++ b/src/collective/flowplayer/browser/js/init.js
@@ -49,9 +49,9 @@
                     // Clip is probably linked as image, so autoplay the clip after image is clicked
                     config.clip.autoPlay = true;
                     // If we know there is splash image, we could at least try to match this size
-                    $(document).ready(function(){
-                        $(this).css("width", $self.find('img').width());
-                        $(this).css("height", $self.find('img').height());
+                    $(window).load(function(){
+                        $self.css("width", $self.find('img').width());
+                        $self.css("height", $self.find('img').height());
                     });
                 }
             }


### PR DESCRIPTION
I have seen some cases where this cause the size to be set to 0.
It seemed that the image has not been fully loaded yet.
Surrounding it with $(document).ready fixed it for me.
